### PR TITLE
Add default case for switch statements

### DIFF
--- a/src/main/java/com/github/joostvdg/cmg/seafarers/model/game/GameCodeInflator.java
+++ b/src/main/java/com/github/joostvdg/cmg/seafarers/model/game/GameCodeInflator.java
@@ -42,6 +42,10 @@ public class GameCodeInflator {
         LOG.info("Inflating Small Game");
         this.game = new SmallGame(code);
         break;
+      //missing default case
+      default:
+          // add default case
+          break;
     }
   }
 


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html